### PR TITLE
Handle callback refs in animation sequence hook

### DIFF
--- a/src/hooks/useMotions.ts
+++ b/src/hooks/useMotions.ts
@@ -181,6 +181,11 @@ export function useAnimationSequence(): AnimationSequenceControls {
 
   const scopeRef = useCallback(
     (node: Element | null) => {
+      if (typeof scope === 'function') {
+        scope(node);
+        return;
+      }
+
       if (scope && typeof scope === 'object') {
         // This is the official pattern from motion/react documentation
         // The scope ref mutation is required by the library's API design


### PR DESCRIPTION
## Summary
- invoke callback refs returned by `useAnimate` within `useAnimationSequence` while retaining the object ref mutation fallback for Motion scopes
- verified animation consumers continue passing `scopeRef` to their root elements for selector-based sequences

## Testing
- npm run lint *(fails: missing eslint-plugin-unused-imports)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f14876610832ab30f7aa0230cfd93)