### PR TITLE
Adjust slide motion variants to end at center

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -218,6 +218,8 @@ export type MotionVariantId =
   | 'slideFromLeft'
   | 'slideFromRight'
   | 'slideFromLeftAndRight'
+  | 'slideLeftToCenter'
+  | 'slideRightToCenter'
   | 'staggerContainer'
   | 'staggerItem'
   | 'cardHover'

--- a/src/utils/motionVariants.ts
+++ b/src/utils/motionVariants.ts
@@ -35,6 +35,22 @@ const WILL_CHANGE_TRANSFORM_OPACITY = {
   willChange: 'transform, opacity' as const,
 };
 
+type SlideDirection = 'left' | 'right';
+
+const createSlideVariant = (offset: number): Variants => ({
+  initial: { opacity: 0, x: offset, ...WILL_CHANGE_TRANSFORM_OPACITY },
+  whileInView: { opacity: 1, x: 0, ...WILL_CHANGE_TRANSFORM_OPACITY },
+});
+
+const createBidirectionalSlideVariant = (): Variants => ({
+  initial: (direction: SlideDirection = 'left') => ({
+    opacity: 0,
+    x: direction === 'right' ? 95 : -95,
+    ...WILL_CHANGE_TRANSFORM_OPACITY,
+  }),
+  whileInView: { opacity: 1, x: 0, ...WILL_CHANGE_TRANSFORM_OPACITY },
+});
+
 const createFadeVariant = (offset = 72): SectionVariant => ({
   initial: { opacity: 0, y: offset, ...WILL_CHANGE_TRANSFORM_OPACITY },
   whileInView: { opacity: 1, y: 0, ...WILL_CHANGE_TRANSFORM_OPACITY },
@@ -54,21 +70,18 @@ const sections: Record<SectionMotionVariantId, SectionVariant> = {
 };
 
 const slides: Record<
-  'slideFromLeft' | 'slideFromRight' | 'slideFromLeftAndRight',
+  | 'slideFromLeft'
+  | 'slideFromRight'
+  | 'slideFromLeftAndRight'
+  | 'slideLeftToCenter'
+  | 'slideRightToCenter',
   Variants
 > = {
-  slideFromLeft: {
-    initial: { opacity: 0, x: -95, ...WILL_CHANGE_TRANSFORM_OPACITY },
-    whileInView: { opacity: 1, x: 0, ...WILL_CHANGE_TRANSFORM_OPACITY },
-  },
-  slideFromRight: {
-    initial: { opacity: 0, x: 95, ...WILL_CHANGE_TRANSFORM_OPACITY },
-    whileInView: { opacity: 1, x: 0, ...WILL_CHANGE_TRANSFORM_OPACITY },
-  },
-  slideFromLeftAndRight: {
-    initial: { opacity: 0, x: -95, ...WILL_CHANGE_TRANSFORM_OPACITY },
-    whileInView: { opacity: 1, x: 95, ...WILL_CHANGE_TRANSFORM_OPACITY },
-  },
+  slideFromLeft: createSlideVariant(-95),
+  slideFromRight: createSlideVariant(95),
+  slideFromLeftAndRight: createBidirectionalSlideVariant(),
+  slideLeftToCenter: createSlideVariant(-95),
+  slideRightToCenter: createSlideVariant(95),
 };
 
 const stagger: StaggerConfig = {


### PR DESCRIPTION
## Summary
- ensure slideFromLeftAndRight slides finish at the center with full opacity while supporting explicit direction
- add reusable slide variant helpers and explicit left/right-to-center options for clearer prop selection

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f14977720832a941d66d7d7a7f29d)