### PR TITLE
Refine motion configuration handling

### DIFF
--- a/src/components/Motions.tsx
+++ b/src/components/Motions.tsx
@@ -28,7 +28,12 @@ function MotionWrapper({
   sectionId,
   ...props
 }: MotionWrapperProps): React.JSX.Element {
-  const { prefersReducedMotion, getTransition } = useAnimationConfig();
+  const {
+    prefersReducedMotion,
+    getTransition,
+    motionViewport,
+    resolveMotionState,
+  } = useAnimationConfig();
   const variant = motionVariants.sections[sectionId] ?? fallbackVariant;
 
   // Calculate delay based on section order
@@ -40,21 +45,22 @@ function MotionWrapper({
       ? 0
       : sectionIndex * BATCH_DELAY_INCREMENT;
 
-  const baseMotion = { opacity: prefersReducedMotion ? 1 : 0, y: 0 };
-  const resolvedInitial: MotionProps['initial'] = prefersReducedMotion
-    ? baseMotion
-    : ((variant.initial ?? baseMotion) as MotionProps['initial']);
-  const resolvedWhileInView: MotionProps['whileInView'] = prefersReducedMotion
-    ? baseMotion
-    : ((variant.whileInView ??
-        variant.animate ?? { opacity: 1 }) as MotionProps['whileInView']);
+  const resolvedInitial: MotionProps['initial'] = resolveMotionState(
+    prefersReducedMotion,
+    (variant.initial ?? { opacity: 0, y: 0 }) as MotionProps['initial']
+  );
+  const resolvedWhileInView: MotionProps['whileInView'] = resolveMotionState(
+    prefersReducedMotion,
+    (variant.whileInView ??
+      variant.animate ?? { opacity: 1, y: 0 }) as MotionProps['whileInView']
+  );
 
   return (
     <motion.div
       initial={resolvedInitial}
       whileInView={resolvedWhileInView}
       transition={getTransition('smooth', { delay: batchDelay })}
-      viewport={{ once: true, amount: 0.15, margin: '0px' }}
+      viewport={motionViewport}
       style={{ position: 'relative' }}
       {...props}
     >

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -239,6 +239,13 @@ export interface AnimationConfig {
     preset?: TransitionPreset,
     overrides?: Partial<Transition>
   ) => Transition;
+  motionViewport: MotionProps['viewport'];
+  reducedMotionTarget: MotionProps['initial'];
+  resolveMotionState: <T extends MotionProps['initial']>(
+    prefersReducedMotion: boolean,
+    state?: T,
+    fallback?: T
+  ) => T;
 }
 
 export type AnimationPriority = 'high' | 'reduced';

--- a/src/features/hero/Hero.tsx
+++ b/src/features/hero/Hero.tsx
@@ -119,7 +119,8 @@ function Hero(): React.JSX.Element {
   } = useToggle(false);
   const profileImageRef = useRef<HTMLImageElement | null>(null);
   const isProfileHovered = useHover(profileImageRef);
-  const { prefersReducedMotion, getTransition } = useAnimationConfig();
+  const { prefersReducedMotion, getTransition, motionViewport } =
+    useAnimationConfig();
   const animationPriority = useAnimationPriority();
   const { value: scrollYProgress } = useScrollProgress();
   const parallaxRange = prefersReducedMotion ? 0 : 80;
@@ -139,6 +140,7 @@ function Hero(): React.JSX.Element {
               initial={imageReveal.initial}
               whileInView={imageReveal.whileInView}
               transition={getTransition('smooth')}
+              viewport={motionViewport}
               style={{ y: parallaxY }}
               sx={{ position: 'relative', display: 'inline-flex' }}
             >
@@ -194,6 +196,7 @@ function Hero(): React.JSX.Element {
               initial={textReveal.initial}
               whileInView={textReveal.whileInView}
               transition={getTransition('smooth')}
+              viewport={motionViewport}
             >
               <Typography
                 variant="h1"

--- a/src/features/projects/Portfolio.tsx
+++ b/src/features/projects/Portfolio.tsx
@@ -14,7 +14,7 @@ import ProjectList from './ProjectList';
 
 // Rendering portfolio section
 function Portfolio(): React.JSX.Element {
-  const { prefersReducedMotion } = useAnimationConfig();
+  const { prefersReducedMotion, motionViewport } = useAnimationConfig();
 
   return (
     <SectionContainer id="portfolio" title="Projects" icon={HiFolder}>
@@ -22,7 +22,7 @@ function Portfolio(): React.JSX.Element {
         variants={motionVariants.stagger.container}
         initial={prefersReducedMotion ? 'show' : 'hidden'}
         whileInView="show"
-        viewport={{ once: true, amount: 0.15 }}
+        viewport={motionViewport}
         style={{ width: '100%' }}
       >
         <Grid container spacing={4}>

--- a/src/hooks/useMotions.ts
+++ b/src/hooks/useMotions.ts
@@ -19,6 +19,7 @@ import type {
   ElementOrSelector,
   MotionValue,
   Transition,
+  MotionProps,
 } from 'motion/react';
 
 import type {
@@ -35,6 +36,24 @@ const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 const BASE_DURATION = 0.65;
 const BASE_DELAY = 0.08;
 const BASE_STAGGER = 0.12;
+const REDUCED_MOTION_TARGET = { opacity: 1, x: 0, y: 0, scale: 1 } as const;
+const MOTION_VIEWPORT: MotionProps['viewport'] = {
+  once: true,
+  amount: 0.15,
+  margin: '0px',
+};
+
+const resolveMotionState = <T extends MotionProps['initial']>(
+  prefersReducedMotion: boolean,
+  state?: T,
+  fallback: T = REDUCED_MOTION_TARGET as T
+): T => {
+  if (prefersReducedMotion) {
+    return fallback;
+  }
+
+  return state ?? fallback;
+};
 
 const subscribeToReducedMotion = (listener: () => void): (() => void) => {
   if (typeof window === 'undefined') {
@@ -105,6 +124,9 @@ export function useAnimationConfig(): AnimationConfig {
     getDelay,
     getStagger,
     getTransition,
+    motionViewport: MOTION_VIEWPORT,
+    reducedMotionTarget: REDUCED_MOTION_TARGET,
+    resolveMotionState,
   };
 }
 


### PR DESCRIPTION
## Summary
- add shared reduced-motion targets and viewport defaults to motion utilities
- reuse shared motion helpers in section wrapper and portfolio grid
- ensure hero reveals respect the shared viewport configuration

## Testing
- npm run lint *(fails: missing eslint-plugin-unused-imports dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f162b3728832abb051a46b52b69e4)