### PR TITLE
Use animation finished promises in section sequence

### DIFF
--- a/src/hooks/useMotions.ts
+++ b/src/hooks/useMotions.ts
@@ -437,56 +437,47 @@ export function useSectionSequence(
     hasPlayed.current = true;
 
     runSequence(async (animate) => {
-      const promises: Promise<void>[] = [];
+      const animationPromises: Promise<void>[] = [];
 
       // Description animation
       if (selectors.description) {
-        promises.push(
-          (
-            animate(
-              selectors.description,
-              { opacity: [0, 1], y: [20, 0] },
-              { duration: 0.5, ease: 'easeOut' }
-            ) as unknown as Promise<void>
-          ).then(() => {})
+        const control = animate(
+          selectors.description,
+          { opacity: [0, 1], y: [20, 0] },
+          { duration: 0.5, ease: 'easeOut' }
         );
+        animationPromises.push(control.finished);
       }
 
       // Cards animation
       if (selectors.cards) {
         // Wait a bit for description if it exists
         const delay = selectors.description ? 0.2 : 0;
-        promises.push(
-          (
-            animate(
-              selectors.cards,
-              { opacity: [0, 1], y: [30, 0] },
-              {
-                delay: getStagger(0.1) + delay,
-                duration: 0.5,
-                ease: 'easeOut',
-              }
-            ) as unknown as Promise<void>
-          ).then(() => {})
+        const control = animate(
+          selectors.cards,
+          { opacity: [0, 1], y: [30, 0] },
+          {
+            delay: getStagger(0.1) + delay,
+            duration: 0.5,
+            ease: 'easeOut',
+          }
         );
+        animationPromises.push(control.finished);
       }
 
       // CTA animation
       if (selectors.cta) {
         const delay =
           (selectors.description ? 0.2 : 0) + (selectors.cards ? 0.4 : 0);
-        promises.push(
-          (
-            animate(
-              selectors.cta,
-              { opacity: [0, 1], scale: [0.9, 1] },
-              { delay, duration: 0.4, ease: 'backOut' }
-            ) as unknown as Promise<void>
-          ).then(() => {})
+        const control = animate(
+          selectors.cta,
+          { opacity: [0, 1], scale: [0.9, 1] },
+          { delay, duration: 0.4, ease: 'backOut' }
         );
+        animationPromises.push(control.finished);
       }
 
-      await Promise.all(promises);
+      await Promise.all(animationPromises);
     });
   });
 }


### PR DESCRIPTION
## Summary
- ensure section sequence animations await animation completion using playback control `finished` promise
- keep existing timing/delay configuration while cleaning up promise handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ad672c74832aba51e81132c4dbf2)