### PR TITLE
Ensure touch navigation stays enabled on mobile

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -893,6 +893,7 @@ export interface ScrollBoundaries {
 export interface UseScrollEventsProps {
   onNavigate: (direction: ScrollDirection) => boolean;
   shouldDisable: boolean;
+  disableNonTouchInputs?: boolean;
   isScrolling: React.MutableRefObject<boolean>;
 }
 

--- a/src/hooks/useFullPageScroll.ts
+++ b/src/hooks/useFullPageScroll.ts
@@ -40,12 +40,15 @@ export function useFullPageScroll(): void {
   const isScrolling = useRef(false);
   const containerRef = useRef<HTMLElement | null>(null);
 
-  const isMobile = useMobileBreakpoint('md');
   const prefersReducedMotion = useReducedMotion();
+  const isTouchPrimaryBreakpoint = useMobileBreakpoint('md');
 
-  // Disable when: reduced motion, mobile view, or scroll not locked (e.g. footer)
-  const shouldDisable = Boolean(
-    prefersReducedMotion || isMobile || !isScrollLocked
+  // Disable all listeners when reduced motion is preferred or scroll lock is off (e.g. footer)
+  const shouldDisable = Boolean(prefersReducedMotion || !isScrollLocked);
+
+  // Wheel/keyboard navigation can be noisy on touch devices; keep gestures active.
+  const disableNonTouchInputs = Boolean(
+    shouldDisable || isTouchPrimaryBreakpoint
   );
 
   // Cache container reference
@@ -89,6 +92,7 @@ export function useFullPageScroll(): void {
   useScrollEvents({
     onNavigate,
     shouldDisable,
+    disableNonTouchInputs,
     isScrolling,
   });
 }

--- a/src/hooks/useScrollEvents.ts
+++ b/src/hooks/useScrollEvents.ts
@@ -21,6 +21,7 @@ function getKeyboardDirection(key: string): ScrollDirection | null {
 export function useScrollEvents({
   onNavigate,
   shouldDisable,
+  disableNonTouchInputs = false,
   isScrolling,
 }: UseScrollEventsProps): void {
   const touchStartY = useRef(0);
@@ -72,19 +73,26 @@ export function useScrollEvents({
 
     const passiveOption = { passive: false };
 
-    window.addEventListener('wheel', handleWheel, passiveOption);
-    window.addEventListener('keydown', handleKeyDown);
+    if (!disableNonTouchInputs) {
+      window.addEventListener('wheel', handleWheel, passiveOption);
+      window.addEventListener('keydown', handleKeyDown);
+    }
+
     window.addEventListener('touchstart', handleTouchStart, passiveOption);
     window.addEventListener('touchend', handleTouchEnd, passiveOption);
 
     return () => {
-      window.removeEventListener('wheel', handleWheel);
-      window.removeEventListener('keydown', handleKeyDown);
+      if (!disableNonTouchInputs) {
+        window.removeEventListener('wheel', handleWheel);
+        window.removeEventListener('keydown', handleKeyDown);
+      }
+
       window.removeEventListener('touchstart', handleTouchStart);
       window.removeEventListener('touchend', handleTouchEnd);
     };
   }, [
     shouldDisable,
+    disableNonTouchInputs,
     handleWheel,
     handleKeyDown,
     handleTouchStart,


### PR DESCRIPTION
## Summary
- avoid disabling full-page scroll on touch devices by basing the disable flag on reduced-motion or scroll-lock state
- gate desktop-specific inputs when mobile while keeping touch gestures active for navigation
- allow useScrollEvents to optionally skip wheel/keyboard listeners without blocking touch events

## Testing
- npm run lint *(fails: missing @tanstack/eslint-plugin-query dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ab75a54cc832a8104a90fea6835a0)